### PR TITLE
sama7g5-ek: OV5647 camera module support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ARCH?=arm
 CC?=$(CROSS_COMPILE)gcc
 DTC_OPTIONS?=-@
 DTC_OPTIONS += -Wno-unit_address_vs_reg -Wno-graph_child_address -Wno-pwms_property
-KERNEL_DIR?=../linux
+KERNEL_DIR?=/home/administrator/work/linux
 KERNEL_BUILD_DIR?=$(shell realpath --relative-to=. $(KERNEL_DIR))
 DTC?=$(KERNEL_BUILD_DIR)/scripts/dtc/dtc
 BDIR?=sam9x60ek sama5d29_curiosity sama5d27_som1_ek sama5d27_wlsom1_ek sama5d2_icp sama5d2_ptc_ek sama5d2_xplained sama5d2_xplained_grts sama5d3_xplained sama5d3_eds sama5d4_xplained sama7g5ek sama7g54_curiosity sam9x60_curiosity sam9x75eb mpfs_icicle mpfs_icicle_amp mpfs_video

--- a/sama7g5ek/sama7g5ek_mipi_ov5647.dtso
+++ b/sama7g5ek/sama7g5ek_mipi_ov5647.dtso
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree file for SAMA7G5-EK board
+ * overlay blob for MIPI with ov5647 sensor. The blob uses MIPI and i2c8
+ *
+ * Copyright (C) 2024 Microchip Technology Inc. and its subsidiaries
+ * Author: Vasanthaselvam R
+ *
+ */
+/dts-v1/;
+/plugin/;
+
+#include "sama7g5-pinfunc.h"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/mfd/atmel-flexcom.h>
+
+&csi_dphy {
+	status = "okay";
+};
+
+
+&csi2host {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	status = "okay";
+
+	port@1 {
+		reg = <1>;
+		csi2host_in: endpoint {
+			remote-endpoint = <&camera_out>;
+			data-lanes = <1 2>;
+			bus-type = <4>;
+			clock-lanes = <0>;
+		};
+	};
+
+	port@2 {
+		reg = <2>;
+		csi2host_out: endpoint {
+			remote-endpoint = <&csi2dc_in>;
+		};
+	};
+};
+
+&csi2dc {
+	status = "okay";
+
+	ports {
+		port@0 {
+			csi2dc_in: endpoint {
+				remote-endpoint = <&csi2host_out>;
+				bus-type = <4>; /* MIPI CSI2 D-PHY */
+			};
+		};
+	};
+};
+
+&flx8 {
+	atmel,flexcom-mode = <ATMEL_FLEXCOM_MODE_TWI>;
+	status = "okay";
+};
+
+&i2c8 {
+	/*
+	 * Camera sensor add-on for OV5647-MIPI-CS
+	 *
+	 *
+	 * Sensor i2c address is fixed at 0x36
+	 *
+	 */
+
+		#address-cells= <1>;
+		#size-cells= <0>;
+		ov5647: camera@36 {
+            		compatible = "ovti,ov5647";
+			reg = <0x36>;
+            		clocks = <&ov5647_clk>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&pinctrl_sensor_reset>;
+            		pwdn-gpios = <&pioA PIN_PE1 GPIO_ACTIVE_HIGH>;
+
+			ov5647_clk: camera-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <25000000>;     //The clock frequency is fixed at 25MHz
+				};
+
+
+            		port {
+                		camera_out: endpoint {
+                   	 		remote-endpoint = <&csi2host_in>;
+					clock-lanes = <0>;
+					data-lanes = <1 2>;
+					link-frequencies = /bits/ 64 <456000000>;
+					clock-noncontinuous;
+               				};
+            		};
+        	};
+    	
+
+ };
+
+&xisc {
+	microchip,mipi-mode;
+	status = "okay";
+};
+
+


### PR DESCRIPTION
New overlay for omnivision OV5647 camera module support. This module uses MIPI and I2C8 interface to integrate OV5647 with SAMA7G5-ek board.